### PR TITLE
fix(calendar): adjust year offset for late lunar months when calendar displaying early months

### DIFF
--- a/cal-china-x.el
+++ b/cal-china-x.el
@@ -294,7 +294,9 @@ shows that it does not recognize Run Yue at all."
   (let* ((cn-years (calendar-chinese-year ; calendar-chinese-year counts from 12 for last year
                     (if (and (eq displayed-month 12) (eq lunar-month 12))
                         (1+ displayed-year)
-                      displayed-year)))
+                      (if (and (<= displayed-month 2) (or (eq lunar-month 10) (eq lunar-month 11)))
+                          (1- displayed-year)
+                        displayed-year))))
          (ret (holiday-lunar-2 (assoc lunar-month cn-years) lunar-day string)))
     (when (and (> (length cn-years) 12) (not (zerop num)))
       (let ((run-yue '())


### PR DESCRIPTION
Corrected the year offset logic to accurately display lunar holidays near the year boundary：
1. Previously, the year calculation didn't account for cases when the displayed month is January or February and the lunar month is after the 10th month, which could cause misalignment of lunar dates like Run Yue (leap months).
2. The fix ensures consistent year mapping for lunar months that span across Gregorian year boundaries.